### PR TITLE
(#13) Allow for empty searches and accent searches

### DIFF
--- a/src/NCI.OCPL.Api.SiteWideSearch/web.config
+++ b/src/NCI.OCPL.Api.SiteWideSearch/web.config
@@ -2,11 +2,11 @@
 <configuration>
   <system.webServer>
     <handlers>
-      <add name="aspNetCore" path="*" verb="*" modules="AspNetCoreModule" resourceType="Unspecified"/>
+      <add name="aspNetCore" path="*" verb="*" modules="AspNetCoreModule" resourceType="Unspecified" />
     </handlers>
-    <aspNetCore processPath="%LAUNCHER_PATH%" arguments="%LAUNCHER_ARGS%" stdoutLogEnabled="false" stdoutLogFile=".\logs\stdout" forwardWindowsAuthToken="false"/>
-	<security>
-      <requestFiltering>
+    <aspNetCore processPath="%LAUNCHER_PATH%" arguments="%LAUNCHER_ARGS%" stdoutLogEnabled="false" stdoutLogFile=".\logs\stdout" forwardWindowsAuthToken="false" />
+    <security>
+      <requestFiltering allowHighBitCharacters="true">
         <fileExtensions allowUnlisted="true" />
       </requestFiltering>
     </security>


### PR DESCRIPTION
* Update web.config to allow for high-bit search strings
* Update controller to return no results on empty search (not error)
* Closes #13