### PR TITLE
(#31) Remove set-env command from integration tests.

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -190,7 +190,7 @@ jobs:
 #              ## Store the exit code off so we can pass this step and
 #              ## capture the test output in the next step, but still
 #              ## fail the entire job
-#              echo ::set-env name=TEST_EXIT_CODE::$?
+#              echo "TEST_EXIT_CODE=$?" >> $GITHUB_ENV
 #              exit 0
 #      - name: Upload Integration test results
 #        uses: actions/upload-artifact@v1

--- a/test/NCI.OCPL.Api.SiteWideSearch.Tests/NCI.OCPL.Api.SiteWideSearch.Tests.csproj
+++ b/test/NCI.OCPL.Api.SiteWideSearch.Tests/NCI.OCPL.Api.SiteWideSearch.Tests.csproj
@@ -19,6 +19,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="coverlet.msbuild" Version="2.8.1">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.6.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
     <PackageReference Include="xunit" Version="2.3.1" />


### PR DESCRIPTION
Update (currently disabled) code to pass TEST_EXIT_CODE
value between steps via environment file.

Close #31 