### PR TITLE
(#52) Run integration tests in CI build

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -123,6 +123,8 @@ jobs:
           ## NOTE: This will be exposed as a random port referenced below by job.services.elasticsearch.ports[9200]
           - 9200/tcp
         options: --health-cmd="curl http://localhost:9200/_cluster/health" --health-interval=10s --health-timeout=5s --health-retries=10
+        volumes:
+          - ${{ github.workspace }}/integration-tests/docker-sws-api/elasticsearch/synonym.txt:/usr/share/elasticsearch/config/synonym.txt
 
     steps:
       - uses: actions/checkout@master
@@ -138,6 +140,10 @@ jobs:
         uses: actions/setup-dotnet@v1
         with:
           dotnet-version: '2.1.607'
+      - name: Debug
+        run: |
+          curl -X GET http://localhost:${{ job.services.elasticsearch.ports[9200] }}
+        shell: bash
       - name: Load Data into elasticsearch & prepare for tests
         env:
           ELASTIC_SEARCH_HOST: http://localhost:${{ job.services.elasticsearch.ports[9200] }}
@@ -145,8 +151,8 @@ jobs:
               ## Create test output and API logging location
               mkdir -p integration-tests/target
 
-#              ## Load the elasticsearch data
-#              ./integration-tests/bin/load-integration-data.sh
+              ## Load the elasticsearch data
+              ./integration-tests/bin/load-integration-data.sh
       - name: Start API
         env:
           Elasticsearch__Servers: http://localhost:${{ job.services.elasticsearch.ports[9200] }}
@@ -179,30 +185,30 @@ jobs:
               done
 
               echo "API is up"
-#      - name: Run Integration Test
-#        ## Normally bash runs with -e which exits the shell upon hitting
-#        ## an error which breaks our capturing of those errors.
-#        shell: bash --noprofile --norc -o pipefail {0}
-#        run: |
-#              ## Run Karate
-#              cd integration-tests && ./bin/karate ./features
-#
-#              ## Store the exit code off so we can pass this step and
-#              ## capture the test output in the next step, but still
-#              ## fail the entire job
-#              echo "TEST_EXIT_CODE=$?" >> $GITHUB_ENV
-#              exit 0
-#      - name: Upload Integration test results
-#        uses: actions/upload-artifact@v1
-#        with:
-#          name: integration-test-results
-#          path: integration-tests/target
-#      - name: Fail build on bad tests
-#        run: |
-#              ## Check if we had errors on the test step, and if so, fail the job
-#              if [ $TEST_EXIT_CODE -ne 0 ]; then
-#                echo "Tests Failed -- See Run Integration Test step or integration-test-results artifact for more information"
-#                exit $TEST_EXIT_CODE
-#              else
-#                echo "Tests passed"
-#              fi
+      - name: Run Integration Test
+        ## Normally bash runs with -e which exits the shell upon hitting
+        ## an error which breaks our capturing of those errors.
+        shell: bash --noprofile --norc -o pipefail {0}
+        run: |
+              ## Run Karate
+              cd integration-tests && ./bin/karate ./features
+
+              ## Store the exit code off so we can pass this step and
+              ## capture the test output in the next step, but still
+              ## fail the entire job
+              echo "TEST_EXIT_CODE=$?" >> $GITHUB_ENV
+              exit 0
+      - name: Upload Integration test results
+        uses: actions/upload-artifact@v1
+        with:
+          name: integration-test-results
+          path: integration-tests/target
+      - name: Fail build on bad tests
+        run: |
+              ## Check if we had errors on the test step, and if so, fail the job
+              if [ $TEST_EXIT_CODE -ne 0 ]; then
+                echo "Tests Failed -- See Run Integration Test step or integration-test-results artifact for more information"
+                exit $TEST_EXIT_CODE
+              else
+                echo "Tests passed"
+              fi

--- a/integration-tests/bin/load-integration-data.sh
+++ b/integration-tests/bin/load-integration-data.sh
@@ -39,25 +39,25 @@ echo "ES status is green"
 
 pushd $DIR/../data/source
 echo "Load the index mappings"
-MAPPING_LOAD_CMD="curl -fsS -H \"Content-Type: application/x-ndjson\" -XPUT ${ELASTIC_HOST}/cgov --data-binary \"@cgov-mapping.json\""
+MAPPING_LOAD_CMD="curl -H \"Content-Type: application/x-ndjson\" --connect-timeout 5 --verbose -XPUT ${ELASTIC_HOST}/autosg --data-binary \"@autosg-mapping.json\""
 mapping_output=$(eval $MAPPING_LOAD_CMD)
 echo $mapping_output
 
-MAPPING_LOAD_CMD="curl -fsS -H \"Content-Type: application/x-ndjson\" -XPUT ${ELASTIC_HOST}/autosg --data-binary \"@autosg-mapping.json\""
+MAPPING_LOAD_CMD="curl -H \"Content-Type: application/x-ndjson\" --connect-timeout 5 --verbose -XPUT ${ELASTIC_HOST}/cgov --data-binary \"@cgov-mapping.json\""
 mapping_output=$(eval $MAPPING_LOAD_CMD)
 echo $mapping_output
 
 
 # Combining the cgov-data files causes the bulk load to fail.
 echo "Load the records"
-BULK_LOAD_CMD="curl -fsS -H \"Content-Type: application/x-ndjson\" -XPOST ${ELASTIC_HOST}/_bulk --data-binary \"@cgov-data-1.jsonl\""
+BULK_LOAD_CMD="curl -H \"Content-Type: application/x-ndjson\" -XPOST ${ELASTIC_HOST}/_bulk --verbose --data-binary \"@cgov-data-1.jsonl\""
 load_output=$(eval $BULK_LOAD_CMD)
 
 ## Test to make sure we loaded items
 ## TODO: Actually check for errors.
 echo $load_output | wc -l
 
-BULK_LOAD_CMD="curl -fsS -H \"Content-Type: application/x-ndjson\" -XPOST ${ELASTIC_HOST}/_bulk --data-binary \"@cgov-data-2.jsonl\""
+BULK_LOAD_CMD="curl -H \"Content-Type: application/x-ndjson\" -XPOST ${ELASTIC_HOST}/_bulk --verbose --data-binary \"@cgov-data-2.jsonl\""
 load_output=$(eval $BULK_LOAD_CMD)
 
 ## Test to make sure we loaded items


### PR DESCRIPTION
* enable instructions to load test data into ElasticSearch
* enable steps which execute the tests and verify their results

Closes #52 