### PR TITLE
(#81) Restore missing tie-breaker in search sort order.

### DIFF
--- a/src/NCI.OCPL.Api.SiteWideSearch/Services/ESSearchQueryService.cs
+++ b/src/NCI.OCPL.Api.SiteWideSearch/Services/ESSearchQueryService.cs
@@ -77,6 +77,11 @@ namespace NCI.OCPL.Api.SiteWideSearch.Services
                     Source = new SourceFilter
                     {
                         Includes = requestedFields
+                    },
+                    Sort = new List<ISort>
+                    {
+                        new FieldSort {Field = "_score"},
+                        new FieldSort {Field = "url"}
                     }
                 };
 

--- a/test/NCI.OCPL.Api.SiteWideSearch.Tests/Services/Search/ESSearchQueryService_Get.cs
+++ b/test/NCI.OCPL.Api.SiteWideSearch.Tests/Services/Search/ESSearchQueryService_Get.cs
@@ -89,6 +89,13 @@ namespace NCI.OCPL.Api.SiteWideSearch.Services.Tests
             string expectedMimeType = "application/json";
             string expectedUrl = "/cgov/_search";
             HttpMethod expectedMethod = HttpMethod.POST;
+            JToken expectedSort = JToken.Parse(@"
+                [
+                    {""_score"": {}},
+                    {""url"": {}}
+                ]
+            ");
+
 
             Uri actualURI = null;
             string actualMimeType = String.Empty;
@@ -138,6 +145,7 @@ namespace NCI.OCPL.Api.SiteWideSearch.Services.Tests
             // The structure of the actual query is tested in the SitewideSearchQueryBuilder_Test class.
             Assert.Equal(requestedSize, ((int)requestBody["size"]));
             Assert.Equal(requestedFrom, (int)requestBody["from"]);
+            Assert.Equal(expectedSort, requestBody["sort"], new JTokenEqualityComparer());
         }
 
     }


### PR DESCRIPTION
Fix #81 