### PR TITLE
(#111) Bump NSwag.AspNetCore to v13.20

### DIFF
--- a/src/NCI.OCPL.Api.SiteWideSearch/NCI.OCPL.Api.SiteWideSearch.csproj
+++ b/src/NCI.OCPL.Api.SiteWideSearch/NCI.OCPL.Api.SiteWideSearch.csproj
@@ -8,7 +8,7 @@
   <ItemGroup>
     <PackageReference Include="NCI.OCPL.Api.Common" Version="2.0.*" />
     <PackageReference Include="NEST" Version="7.9.*" />
-    <PackageReference Include="NSwag.AspNetCore" Version="13.11.*" />
+    <PackageReference Include="NSwag.AspNetCore" Version="13.20.*" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Closes #111

Testing needs:
- Standard regression tests
- Verify navigating to https://webapis-dev.cancer.gov/sitewidesearch/v1/index.html?configUrl=https://jumpy-floor.surge.sh/test.json displays the Sitewide Search Swagger page.