### PR TITLE
(#118, #119) Sanitize inputs to logging.

### DIFF
--- a/integration-tests/docker-sws-api/api/Dockerfile
+++ b/integration-tests/docker-sws-api/api/Dockerfile
@@ -1,5 +1,5 @@
 # Build runtime image
-FROM mcr.microsoft.com/dotnet/sdk:6.0
+FROM mcr.microsoft.com/dotnet/sdk:8.0
 WORKDIR /app
 
 # Get the NIH Root certificates and install them so we work on VPN

--- a/integration-tests/features/search/term.feature
+++ b/integration-tests/features/search/term.feature
@@ -43,6 +43,12 @@ Feature: Search Term
     Scenario Outline: Images do not appear in the results when searching for image-specific terms.
         for collection: <collection>, lang: <lang>, term: <term>, from: from, size: <size>, site: <site>
 
+        # These tests are expected/permitted to return emtpy arrays.
+        # Karate 1.4.1 introduced a breaking change in wich match each defauts to failing
+        # if the array is empty.  Fortunately, we can configure around it.
+        # https://github.com/karatelabs/karate/releases/tag/v1.4.1
+        * configure matchEachEmptyAllowed = true
+
         Given path 'Search', collection, lang, term
         And param from = from
         And param size = size

--- a/src/NCI.OCPL.Api.SiteWideSearch/Services/ESAutosuggestQueryService.cs
+++ b/src/NCI.OCPL.Api.SiteWideSearch/Services/ESAutosuggestQueryService.cs
@@ -85,7 +85,8 @@ namespace NCI.OCPL.Api.SiteWideSearch.Services
             }
             else
             {
-                string message = $"Invalid response when searching for '{term}'.";
+                string message = $"Invalid response when searching for '{term}'."
+                    .Replace(Environment.NewLine, String.Empty);
                 _logger.LogError(message);
                 _logger.LogError(response.DebugInformation);
                 throw new APIInternalException("errors occured.");

--- a/src/NCI.OCPL.Api.SiteWideSearch/Services/ESSearchQueryService.cs
+++ b/src/NCI.OCPL.Api.SiteWideSearch/Services/ESSearchQueryService.cs
@@ -104,7 +104,8 @@ namespace NCI.OCPL.Api.SiteWideSearch.Services
             }
             else
             {
-                string message = $"Invalid response when searching for '{term}'.";
+                string message = $"Invalid response when searching for '{term}'."
+                    .Replace(Environment.NewLine, String.Empty);
                 _logger.LogError(message);
                 _logger.LogError(response.DebugInformation);
                 throw new APIInternalException("Error occured.");


### PR DESCRIPTION
- Moves API container to .Net 8. (#119)
- Update karate.jar to v1.5.1
- Tweak test config to allow empty arrays in comparison (breaking change in karate).

Closes #118
Fixes #119